### PR TITLE
fix(SAEPB0199 Ajustes): SAEPB0199M001108 Ajustes en creación de permisos

### DIFF
--- a/app/services/shift_for_employees_service.ts
+++ b/app/services/shift_for_employees_service.ts
@@ -88,6 +88,7 @@ export default class ShiftForEmployeeService {
             shiftRestDays: record.shift.shiftRestDays,
             shiftCreatedAt: record.shift.shiftCreatedAt,
             shiftUpdatedAt: record.shift.shiftUpdatedAt,
+            shiftCalculateFlag: record.shift.shiftCalculateFlag,
           },
         })
         return acc

--- a/database/migrations/1735589224982_create_add_system_module_id_foreign_to_system_permissions_table.ts
+++ b/database/migrations/1735589224982_create_add_system_module_id_foreign_to_system_permissions_table.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'system_permissions'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.foreign('system_module_id').references('system_modules.system_module_id')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropForeign('system_module_id')
+    })
+  }
+}


### PR DESCRIPTION
se agrego la llave foranea de system_module_id en la tabla de system_permissions con migracion y se en el servicio de shift_for_employees_se agrego la propiedad de shift_calculate_flat para poder hacer una validacion en el bo