### PR TITLE
fix(SAEPB0108 Vacaciones): 25SAEPB0108M004058 Bloquear asignación de …

### DIFF
--- a/app/controllers/system_setting_controller.ts
+++ b/app/controllers/system_setting_controller.ts
@@ -200,6 +200,11 @@ export default class SystemSettingController {
    *                 type: number
    *                 description: System setting tolerance count per absence
    *                 required: false
+   *               systemSettingRestrictFutureVacation:
+   *                 type: boolean
+   *                 description: System setting restrict future vacation
+   *                 required: false
+   *                 default: true
    *     responses:
    *       '201':
    *         description: Resource processed successfully
@@ -287,6 +292,7 @@ export default class SystemSettingController {
       const systemSettingSidebarColor = request.input('systemSettingSidebarColor')
       const systemSettingActive = request.input('systemSettingActive')
       const systemSettingToleranceCountPerAbsence = request.input('systemSettingToleranceCountPerAbsence')
+      const systemSettingRestrictFutureVacation = request.input('systemSettingRestrictFutureVacation')
       const systemSetting = {
         systemSettingTradeName: systemSettingTradeName,
         systemSettingSidebarColor: systemSettingSidebarColor,
@@ -295,6 +301,10 @@ export default class SystemSettingController {
             ? 1
             : 0,
         systemSettingToleranceCountPerAbsence: systemSettingToleranceCountPerAbsence,
+        systemSettingRestrictFutureVacation:
+        systemSettingRestrictFutureVacation && (systemSettingRestrictFutureVacation === 'true' || systemSettingRestrictFutureVacation === '1')
+            ? 1
+            : 0,
       } as SystemSetting
       const systemSettingService = new SystemSettingService()
       const data = await request.validateUsing(createSystemSettingValidator)
@@ -476,6 +486,11 @@ export default class SystemSettingController {
    *                 type: number
    *                 description: System setting tolerance count per absence
    *                 required: false
+   *               systemSettingRestrictFutureVacation:
+   *                 type: boolean
+   *                 description: System setting restrict future vacation
+   *                 required: false
+   *                 default: true
    *     responses:
    *       '200':
    *         description: Resource processed successfully
@@ -564,6 +579,7 @@ export default class SystemSettingController {
       const systemSettingSidebarColor = request.input('systemSettingSidebarColor')
       const systemSettingActive = request.input('systemSettingActive')
       const systemSettingToleranceCountPerAbsence = request.input('systemSettingToleranceCountPerAbsence')
+      const systemSettingRestrictFutureVacation = request.input('systemSettingRestrictFutureVacation')
       const systemSetting = {
         systemSettingId: systemSettingId,
         systemSettingTradeName: systemSettingTradeName,
@@ -573,6 +589,10 @@ export default class SystemSettingController {
             ? 1
             : 0,
         systemSettingToleranceCountPerAbsence: systemSettingToleranceCountPerAbsence,
+        systemSettingRestrictFutureVacation:
+        systemSettingRestrictFutureVacation && (systemSettingRestrictFutureVacation === 'true' || systemSettingRestrictFutureVacation === '1')
+            ? 1
+            : 0,
       } as SystemSetting
       if (!systemSettingId) {
         response.status(400)

--- a/app/models/system_setting.ts
+++ b/app/models/system_setting.ts
@@ -39,6 +39,9 @@ import type { HasMany } from '@adonisjs/lucid/types/relations'
  *          systemSettingActive:
  *            type: number
  *            description: System setting status
+ *          systemSettingRestrictFutureVacation:
+ *            type: number
+ *            description: System setting restrict future vacations
  *          systemSettingCreatedAt:
  *            type: string
  *          systemSettingUpdatedAt:
@@ -74,6 +77,9 @@ export default class SystemSetting extends compose(BaseModel, SoftDeletes) {
 
   @column()
   declare systemSettingToleranceCountPerAbsence: number
+
+  @column()
+  declare systemSettingRestrictFutureVacation: number
 
   @column.dateTime({ autoCreate: true })
   declare systemSettingCreatedAt: DateTime

--- a/app/services/system_setting_service.ts
+++ b/app/services/system_setting_service.ts
@@ -47,6 +47,7 @@ export default class SystemSettingService {
     newSystemSetting.systemSettingActive = systemSetting.systemSettingActive
     newSystemSetting.systemSettingBusinessUnits = systemSetting.systemSettingBusinessUnits
     newSystemSetting.systemSettingToleranceCountPerAbsence = systemSetting.systemSettingToleranceCountPerAbsence
+    newSystemSetting.systemSettingRestrictFutureVacation = systemSetting.systemSettingRestrictFutureVacation
     await newSystemSetting.save()
     return newSystemSetting
   }
@@ -59,6 +60,7 @@ export default class SystemSettingService {
     currentSystemSetting.systemSettingFavicon = systemSetting.systemSettingFavicon
     currentSystemSetting.systemSettingActive = systemSetting.systemSettingActive
     currentSystemSetting.systemSettingToleranceCountPerAbsence = systemSetting.systemSettingToleranceCountPerAbsence
+    currentSystemSetting.systemSettingRestrictFutureVacation = systemSetting.systemSettingRestrictFutureVacation
     await currentSystemSetting.save()
     return currentSystemSetting
   }

--- a/database/migrations/1755531061284_create_add_system_setting_restrict_future_vacation_to_system_settings_table.ts
+++ b/database/migrations/1755531061284_create_add_system_setting_restrict_future_vacation_to_system_settings_table.ts
@@ -1,0 +1,21 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'system_settings'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table
+        .tinyint('system_setting_restrict_future_vacation')
+        .after('system_setting_tolerance_count_per_absence')
+        .nullable()
+        .defaultTo(0)
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('system_setting_restrict_future_vacation')
+    })
+  }
+}


### PR DESCRIPTION
…vacaciones a perdios futuros por regla

se agrego en la tabla system settings la propiedad systemSettingRestrictFutureVacation para validar en el front cuando una empresa quiera bloquear asignar dias de vacaciones en periodos futuros cuando aún hay dias disponibles en periodos pasados , se agrego la migracion, se modifico el servicio de store y update y el controlador de esa tabla